### PR TITLE
Add generic type support

### DIFF
--- a/shogun/argparse_/args.py
+++ b/shogun/argparse_/args.py
@@ -1,7 +1,9 @@
 import dataclasses
-from typing import Sequence
+from typing import Callable, Optional, Sequence, TypeVar
 
 from shogun.utils import remove_dict_nones
+
+T = TypeVar("T")
 
 
 def arg(
@@ -12,6 +14,7 @@ def arg(
     help=None,
     metavar=None,
     aliases: Sequence[str] = (),
+    converter: Optional[Callable[[str], T]] = None,
     **kwargs,
 ):
     """
@@ -44,6 +47,7 @@ def arg(
                 help=help,
                 metavar=metavar,
                 aliases=aliases,
+                converter=converter,
             )
         ),
         default=default,

--- a/shogun/argparse_/parse.py
+++ b/shogun/argparse_/parse.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from collections import deque
+from collections import OrderedDict, deque
 from typing import Any, Dict, Optional, Sequence, Type, TypeVar
 
 from shogun.dispatch import TypeRegistry
@@ -12,7 +12,7 @@ def build_record_instance_from_parsed_args(
     record_class: RecordClass, args: Dict[str, Any]
 ):
     # New dictionary of args guaranteed to iterate by sorted key
-    args = {k: v for k, v in sorted(args.items())}
+    args = OrderedDict({k: v for k, v in sorted(args.items())})
     unpacked = {}
     for field_name, field in sorted(record_class.fields_dict().items()):
         for arg_name in list(args):

--- a/shogun/argparse_/utils.py
+++ b/shogun/argparse_/utils.py
@@ -11,4 +11,4 @@ def field_name_to_arg_name(name: str, underscore_to_hyphen: bool = True) -> str:
 
 
 def common_kwargs(field: "RecordField"):
-    return {"type": field.type, **filter_dict(field.metadata, {"aliases"})}
+    return {"type": field.type, **filter_dict(field.metadata, {"aliases", "converter"})}

--- a/shogun/dispatch/concrete/__init__.py
+++ b/shogun/dispatch/concrete/__init__.py
@@ -1,4 +1,7 @@
 import shogun.dispatch.concrete.attrs
 import shogun.dispatch.concrete.bool
 import shogun.dispatch.concrete.dataclass
+import shogun.dispatch.concrete.default
 import shogun.dispatch.concrete.enum_
+import shogun.dispatch.concrete.generic_container
+import shogun.dispatch.concrete.literal

--- a/shogun/dispatch/concrete/attrs.py
+++ b/shogun/dispatch/concrete/attrs.py
@@ -7,6 +7,8 @@ except ImportError:
 else:
 
     class DispatcherIsAttrs(DispatcherIsRecordClass):
+        priority: int = 1
+
         @classmethod
         def is_type(cls, field_type: type) -> bool:
             return attr.has(field_type)

--- a/shogun/dispatch/concrete/bool.py
+++ b/shogun/dispatch/concrete/bool.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
-from ...argparse_.utils import common_kwargs
-from ...utils import filter_dict
 from shogun.argparse_.action import FieldAction
+from shogun.argparse_.utils import common_kwargs
+from shogun.utils import filter_dict
 from ..base import DispatcherIsSubclass
 
 if TYPE_CHECKING:
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 class DispatcherBool(DispatcherIsSubclass):
+    priority: int = 1
     type_ = bool
 
     @classmethod

--- a/shogun/dispatch/concrete/dataclass.py
+++ b/shogun/dispatch/concrete/dataclass.py
@@ -4,6 +4,8 @@ from shogun.dispatch.record_class import DispatcherIsRecordClass
 
 
 class DispatcherIsDataclass(DispatcherIsRecordClass):
+    priority: int = 1
+
     @classmethod
     def is_type(cls, field_type: type) -> bool:
         return dataclasses.is_dataclass(field_type)

--- a/shogun/dispatch/concrete/default.py
+++ b/shogun/dispatch/concrete/default.py
@@ -1,16 +1,22 @@
-from typing import Any, TYPE_CHECKING
+import sys
+from typing import Any, Sequence, TYPE_CHECKING, Type
 
 from shogun.argparse_.action import FieldAction
 from shogun.argparse_.utils import common_kwargs
+from shogun.dispatch.base import DispatcherBase
 
 if TYPE_CHECKING:
     from shogun.records.generic import RecordField
 
 
-# Note this doesn't inherit from the dispatch base because we don't want to
-# register this class otherwise the order of imports determines the order of
-# dispatch parsing
-class DispatcherDefault:
+class DispatcherDefault(DispatcherBase):
+    # Should always be last
+    priority: int = sys.maxsize
+
+    @classmethod
+    def is_type(cls, field_type: Type) -> bool:
+        return True
+
     @classmethod
     def build_action(cls, field: "RecordField", **kwargs: Any) -> FieldAction:
         kwargs = {
@@ -23,3 +29,7 @@ class DispatcherDefault:
             field,
             kwargs=kwargs,
         )
+
+    @classmethod
+    def build_actions(cls, field: "RecordField") -> Sequence[FieldAction]:
+        return [cls.build_action(field)]

--- a/shogun/dispatch/concrete/enum_.py
+++ b/shogun/dispatch/concrete/enum_.py
@@ -4,13 +4,15 @@ from typing import TYPE_CHECKING
 
 from shogun.argparse_.action import FieldAction
 from shogun.dispatch.base import DispatcherIsSubclass
-from shogun.dispatch.default import DispatcherDefault
+from shogun.dispatch.concrete.default import DispatcherDefault
 
 if TYPE_CHECKING:
     from shogun.records.generic import RecordField
 
 
 class DispatcherEnum(DispatcherIsSubclass):
+    priority: int = 1
+
     type_ = Enum
 
     @classmethod

--- a/shogun/dispatch/concrete/generic_container.py
+++ b/shogun/dispatch/concrete/generic_container.py
@@ -1,0 +1,39 @@
+import dataclasses
+from typing import Sequence, TYPE_CHECKING, Type
+
+from shogun.argparse_.action import FieldAction
+from shogun.dispatch.base import DispatcherBase
+from shogun.dispatch.concrete.default import DispatcherDefault
+from shogun.generics import get_generic_origin
+
+if TYPE_CHECKING:
+    from shogun.records.generic import RecordField
+
+
+class DispatcherGenericContainer(DispatcherBase):
+    priority: int = 2
+
+    @classmethod
+    def is_type(cls, field_type: Type) -> bool:
+        return get_generic_origin(field_type) is not None
+
+    @classmethod
+    def build_actions(cls, field: "RecordField") -> Sequence[FieldAction]:
+        if field.converter is None:
+            raise ValueError(
+                "Generic container types cannot be automatically parsed and "
+                "must be parsed using a 'convert' method"
+            )
+
+        # Here we have to do something different for dataclasses because they
+        # don't natively support converter methods like attr.s classes do
+        field_type = str
+        if isinstance(field.field, dataclasses.Field):
+            field_type = field.converter
+
+        return [
+            DispatcherDefault.build_action(
+                field,
+                type=field_type,
+            )
+        ]

--- a/shogun/dispatch/concrete/literal.py
+++ b/shogun/dispatch/concrete/literal.py
@@ -1,0 +1,49 @@
+from argparse import ArgumentTypeError
+from typing import Sequence, TYPE_CHECKING
+
+from typing_extensions import Literal
+
+from shogun.argparse_.action import FieldAction
+from shogun.dispatch.base import DispatcherBase
+from shogun.dispatch.concrete.default import DispatcherDefault
+from shogun.generics import get_generic_args, get_generic_origin
+from shogun.utils import IS_PYTHON_36
+
+if TYPE_CHECKING:
+    from shogun.records.generic import RecordField
+
+
+class DispatcherLiteral(DispatcherBase):
+    priority: int = 1
+
+    @classmethod
+    def is_type(cls, field_type: type) -> bool:
+        try:
+            # subclass check is for Python 3.6
+            return get_generic_origin(field_type) is Literal or issubclass(
+                type(field_type), type(Literal)
+            )
+        except TypeError:
+            return False
+
+    @classmethod
+    def build_actions(cls, field: "RecordField") -> Sequence[FieldAction]:
+        literal_values = get_generic_args(field.type)
+        if not literal_values and IS_PYTHON_36:
+            literal_values = field.type.__values__
+
+        def literal_type_func(value):
+            if value not in literal_values:
+                raise ArgumentTypeError(
+                    f"invalid choice: {value!r} (choose from {literal_values})"
+                )
+            return value
+
+        return [
+            DispatcherDefault.build_action(
+                field,
+                type=literal_type_func,
+                choices=literal_values,
+                metavar=f"{{{','.join(literal_values)}}}",
+            )
+        ]

--- a/shogun/dispatch/registry.py
+++ b/shogun/dispatch/registry.py
@@ -1,7 +1,7 @@
-from typing import List, Sequence, TYPE_CHECKING, Type
+from collections import defaultdict
+from typing import Dict, Iterable, List, Sequence, TYPE_CHECKING, Type
 
 from shogun.argparse_.action import FieldAction
-from .default import DispatcherDefault
 
 if TYPE_CHECKING:
     from shogun.records.generic import RecordField
@@ -10,16 +10,22 @@ if TYPE_CHECKING:
 
 class TypeRegistry:
     # Intentionally static
-    dispatch: List[Type["DispatcherBase"]] = []
+    _dispatch: Dict[int, List[Type["DispatcherBase"]]] = defaultdict(list)
+
+    @classmethod
+    def dispatchers(cls) -> Iterable[Type["DispatcherBase"]]:
+        for priority, dispatchers in sorted(cls._dispatch.items()):
+            for dispatcher in dispatchers:
+                yield dispatcher
 
     @classmethod
     def build_actions(cls, field: "RecordField") -> Sequence[FieldAction]:
-        for dispatcher in cls.dispatch:
+        for dispatcher in cls.dispatchers():
             if dispatcher.is_type(field.type):
                 return dispatcher.build_actions(field)
 
-        return (DispatcherDefault.build_action(field),)
+        raise ValueError(f"Unexpected type for field: {field.type}")
 
     @classmethod
     def register(cls, dispatcher_type: Type["DispatcherBase"]) -> None:
-        cls.dispatch.append(dispatcher_type)
+        cls._dispatch[dispatcher_type.priority].append(dispatcher_type)

--- a/shogun/generics.py
+++ b/shogun/generics.py
@@ -1,0 +1,70 @@
+import collections
+import typing
+
+BUILTINS_MAPPING = {
+    typing.ByteString: bytes,
+    typing.Dict: dict,
+    typing.List: list,
+    typing.Set: set,
+    typing.Tuple: tuple,
+}
+
+GenericCls = type(typing.List)
+UnionCls = type(typing.Union)
+
+IS_PYTHON_38 = hasattr(typing, "get_origin")
+IS_PYTHON_37 = hasattr(typing.List, "_special")
+
+
+def _convert_to_builtin(type_):
+    if type_ in BUILTINS_MAPPING:
+        return BUILTINS_MAPPING[type_]
+    return type_
+
+
+def _found_args_from__args__(type_):
+    found_args = type_.__args__
+    if (
+        get_generic_origin(type_) is collections.abc.Callable
+        and found_args[0] is not Ellipsis
+    ):
+        found_args = (list(found_args[:-1]), found_args[-1])
+    return found_args
+
+
+def get_generic_origin(type_):
+    origin = None
+    if IS_PYTHON_38:
+        origin = typing.get_origin(type_)
+    elif IS_PYTHON_37:
+        if isinstance(type_, GenericCls) and not type_._special:
+            origin = type_.__origin__
+        elif hasattr(type_, "_special") and type_._special:
+            origin = type_
+        elif type_ is typing.Generic:
+            origin = typing.Generic
+    else:  # python 3.6
+        if isinstance(type_, GenericCls):
+            origin = type_.__origin__
+            if origin is None:
+                origin = type_
+        elif isinstance(type_, UnionCls):
+            origin = type_.__origin__
+        elif type_ is typing.Generic:
+            origin = typing.Generic
+
+    return _convert_to_builtin(origin)
+
+
+def get_generic_args(type_):
+    found_args = tuple()
+
+    if IS_PYTHON_38:
+        found_args = typing.get_args(type_)
+    elif IS_PYTHON_37:
+        if isinstance(type_, GenericCls) and not type_._special:
+            found_args = _found_args_from__args__(type_)
+    else:  # python 3.6
+        if isinstance(type_, (GenericCls, UnionCls)):
+            found_args = _found_args_from__args__(type_)
+    return tuple() if found_args is None else found_args

--- a/shogun/records/attrs.py
+++ b/shogun/records/attrs.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, Mapping, Optional, Type, TypeVar
+
 from .generic import RecordClass, RecordField
 
 try:
@@ -5,16 +7,48 @@ try:
 except ImportError:
     pass
 else:
+    T = TypeVar("T")
 
-    class AttrField(RecordField[attr.Attribute]):
+    class AttrField(RecordField[attr.Attribute, T]):
+        @property
+        def default(self) -> T:
+            # attrs lies about the type of this and pretends its a method
+            # so we skip mypy typing and shut PyCharm up by importing the
+            # real class here
+            from attr._make import Factory
+
+            default = self.field.default
+            if isinstance(default, Factory):
+                if default.takes_self:
+                    raise ValueError("takes_self currently not supported")
+                default = default.factory()
+            return default
+
+        @property
+        def converter(self) -> Optional[Callable[[str], T]]:
+            return self.field.converter
+
+        @property
+        def name(self) -> str:
+            return self.field.name
+
+        @property
+        def type(self) -> Type[T]:
+            assert self.field.type is not None
+            return self.field.type
+
+        @property
+        def metadata(self) -> Mapping[str, Any]:
+            return self.field.metadata
+
         def is_required(self) -> bool:
-            return self.field.default is attr.NOTHING
+            return self.default is attr.NOTHING
 
     class AttrClass(RecordClass[attr.Attribute]):
         fields_attribute = "__attrs_attrs__"
         field_wrapper_type = AttrField
 
-        def fields_dict(self):
+        def fields_dict(self) -> Mapping[str, RecordField]:
             assert attr.has(self.cls)
             return {
                 name: self.get_field(field)

--- a/shogun/records/dataclass.py
+++ b/shogun/records/dataclass.py
@@ -1,16 +1,46 @@
 import dataclasses
-from typing import Mapping
+from typing import Any, Callable, Mapping, Optional, Type, TypeVar, cast
 
-from shogun.records.generic import FieldType, RecordClass, RecordField
+from shogun.records.generic import RecordClass, RecordField
+
+T = TypeVar("T")
 
 
-class DataField(RecordField[dataclasses.Field]):
+class DataField(RecordField[dataclasses.Field, T]):
     """
     Represents a dataclass field.
     """
 
+    @property
+    def default(self) -> T:
+        # TODO: https://github.com/python/mypy/issues/6910
+        #       Have to work around what looks like a weird mypy bug with dataclasses
+        default_factory = cast(
+            Optional[Callable[[], T]], getattr(self.field, "default_factory")
+        )
+        if default_factory is not None and default_factory is not dataclasses.MISSING:
+            return default_factory()
+        else:
+            return self.field.default
+
+    @property
+    def converter(self) -> Optional[Callable[[str], T]]:
+        return self.field.metadata.get("converter")
+
+    @property
+    def name(self) -> str:
+        return self.field.name
+
+    @property
+    def type(self) -> Type[T]:
+        return self.field.type
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        return self.field.metadata
+
     def is_required(self) -> bool:
-        return self.field.default is dataclasses.MISSING
+        return self.default is dataclasses.MISSING
 
 
 class DataClass(RecordClass[dataclasses.Field]):
@@ -21,7 +51,7 @@ class DataClass(RecordClass[dataclasses.Field]):
     fields_attribute = "__dataclass_fields__"
     field_wrapper_type = DataField
 
-    def fields_dict(self) -> Mapping[str, FieldType]:
+    def fields_dict(self) -> Mapping[str, RecordField]:
         assert dataclasses.is_dataclass(self.cls)
         fields = dataclasses.fields(self.cls)
         return {field.name: self.get_field(field) for field in fields}

--- a/shogun/utils.py
+++ b/shogun/utils.py
@@ -1,9 +1,18 @@
-from typing import Any, Container, Dict
+import sys
+from distutils.version import StrictVersion
+from typing import Any, Container, Dict, Mapping
+
+PY_VER = StrictVersion(f"{sys.version_info.major}.{sys.version_info.minor}")
 
 
-def filter_dict(dct: Dict[str, Any], remove_keys: Container[str]) -> Dict[str, Any]:
+IS_PYTHON_36 = PY_VER == StrictVersion("3.6")
+IS_PYTHON_37 = PY_VER == StrictVersion("3.7")
+IS_GT_PYTHON_38 = PY_VER >= StrictVersion("3.8")
+
+
+def filter_dict(dct: Mapping[str, Any], remove_keys: Container[str]) -> Dict[str, Any]:
     return {key: value for key, value in dct.items() if key not in remove_keys}
 
 
-def remove_dict_nones(dct: Dict[str, Any]) -> Dict[str, Any]:
+def remove_dict_nones(dct: Mapping[str, Any]) -> Dict[str, Any]:
     return {key: value for key, value in dct.items() if value is not None}


### PR DESCRIPTION
Allows supporting two new types: `Literal` and generic types like `Sequence` by using `converters` which are borrowed from `attrs`.

```
from dataclasses import asdict, dataclass
from pathlib import Path
from pprint import pprint
from typing import Sequence

from typing_extensions import Literal

from shogun import arg, parse
from shogun.argparse_.parser import NoExitArgumentParser


@dataclass()
class Args:
    url: str
    output_path: Path
    verbose: bool
    retries: int = 3
    choices: Literal['r', 'rb', 'w', 'wb'] = 'r'
    items: Sequence[str] = arg(default_factory=list, converter=lambda x: x.split(','))


parameters = parse(
    Args, ["--url", "test.com", "--output-path", "/tmp", "--verbose", "--retries", "3", '--items',
           "1,2,3"], parser=NoExitArgumentParser())
pprint(asdict(parameters))
```