### PR TITLE
Change priorities to work high to low

### DIFF
--- a/shogun/dispatch/base.py
+++ b/shogun/dispatch/base.py
@@ -1,10 +1,18 @@
 import inspect
 from abc import ABCMeta, abstractmethod
+from enum import IntEnum, auto
 from typing import Sequence, Type
 
 from shogun.argparse_.action import FieldAction
 from shogun.dispatch.registry import TypeRegistry
 from shogun.records.generic import RecordField
+
+
+class DispatchPriority(IntEnum):
+    LOWEST = auto()
+    GENERIC_CONTAINERS = auto()
+    SIMPLE_TYPES = auto()
+    USER_HIGH_PRIORITY = auto()
 
 
 class DispatcherBase(metaclass=ABCMeta):
@@ -15,9 +23,14 @@ class DispatcherBase(metaclass=ABCMeta):
      1. Priority
      2. Order added into priority list
 
-    Priority is determined as closest to 1 is highest priority e.g
+    Priority is determined by integer ordering (highest to lowest, >= 0) e.g
 
-        1 > 2 > 3 ...
+        3 classes with priorities (0, 1, 2) respectively
+
+        Dispatched:
+            First priority 2
+            Next priority 1
+            Last priority 0
     """
 
     priority: int
@@ -29,6 +42,9 @@ class DispatcherBase(metaclass=ABCMeta):
                 raise TypeError(
                     f"{cls.__name__} must define 'priority' class attribute"
                 )
+            if cls.priority < 0:
+                raise TypeError(f"{cls.__name__} must define a priority >= 0")
+
             TypeRegistry.register(cls)
 
     @classmethod

--- a/shogun/dispatch/concrete/attrs.py
+++ b/shogun/dispatch/concrete/attrs.py
@@ -1,3 +1,4 @@
+from shogun.dispatch.base import DispatchPriority
 from shogun.dispatch.record_class import DispatcherIsRecordClass
 
 try:
@@ -7,7 +8,7 @@ except ImportError:
 else:
 
     class DispatcherIsAttrs(DispatcherIsRecordClass):
-        priority: int = 1
+        priority: int = DispatchPriority.SIMPLE_TYPES
 
         @classmethod
         def is_type(cls, field_type: type) -> bool:

--- a/shogun/dispatch/concrete/bool.py
+++ b/shogun/dispatch/concrete/bool.py
@@ -3,14 +3,14 @@ from typing import TYPE_CHECKING
 from shogun.argparse_.action import FieldAction
 from shogun.argparse_.utils import common_kwargs
 from shogun.utils import filter_dict
-from ..base import DispatcherIsSubclass
+from ..base import DispatchPriority, DispatcherIsSubclass
 
 if TYPE_CHECKING:
     from shogun.records.generic import RecordField
 
 
 class DispatcherBool(DispatcherIsSubclass):
-    priority: int = 1
+    priority: int = DispatchPriority.SIMPLE_TYPES
     type_ = bool
 
     @classmethod

--- a/shogun/dispatch/concrete/dataclass.py
+++ b/shogun/dispatch/concrete/dataclass.py
@@ -1,10 +1,11 @@
 import dataclasses
 
+from shogun.dispatch.base import DispatchPriority
 from shogun.dispatch.record_class import DispatcherIsRecordClass
 
 
 class DispatcherIsDataclass(DispatcherIsRecordClass):
-    priority: int = 1
+    priority: int = DispatchPriority.SIMPLE_TYPES
 
     @classmethod
     def is_type(cls, field_type: type) -> bool:

--- a/shogun/dispatch/concrete/default.py
+++ b/shogun/dispatch/concrete/default.py
@@ -1,9 +1,8 @@
-import sys
 from typing import Any, Sequence, TYPE_CHECKING, Type
 
 from shogun.argparse_.action import FieldAction
 from shogun.argparse_.utils import common_kwargs
-from shogun.dispatch.base import DispatcherBase
+from shogun.dispatch.base import DispatchPriority, DispatcherBase
 
 if TYPE_CHECKING:
     from shogun.records.generic import RecordField
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
 
 class DispatcherDefault(DispatcherBase):
     # Should always be last
-    priority: int = sys.maxsize
+    priority: int = DispatchPriority.LOWEST
 
     @classmethod
     def is_type(cls, field_type: Type) -> bool:

--- a/shogun/dispatch/concrete/enum_.py
+++ b/shogun/dispatch/concrete/enum_.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from shogun.argparse_.action import FieldAction
-from shogun.dispatch.base import DispatcherIsSubclass
+from shogun.dispatch.base import DispatchPriority, DispatcherIsSubclass
 from shogun.dispatch.concrete.default import DispatcherDefault
 
 if TYPE_CHECKING:
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class DispatcherEnum(DispatcherIsSubclass):
-    priority: int = 1
+    priority: int = DispatchPriority.SIMPLE_TYPES
 
     type_ = Enum
 

--- a/shogun/dispatch/concrete/generic_container.py
+++ b/shogun/dispatch/concrete/generic_container.py
@@ -1,8 +1,9 @@
-import dataclasses
 from typing import Sequence, TYPE_CHECKING, Type
 
+import dataclasses
+
 from shogun.argparse_.action import FieldAction
-from shogun.dispatch.base import DispatcherBase
+from shogun.dispatch.base import DispatchPriority, DispatcherBase
 from shogun.dispatch.concrete.default import DispatcherDefault
 from shogun.generics import get_generic_origin
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class DispatcherGenericContainer(DispatcherBase):
-    priority: int = 2
+    priority: int = DispatchPriority.GENERIC_CONTAINERS
 
     @classmethod
     def is_type(cls, field_type: Type) -> bool:

--- a/shogun/dispatch/concrete/literal.py
+++ b/shogun/dispatch/concrete/literal.py
@@ -4,7 +4,7 @@ from typing import Sequence, TYPE_CHECKING
 from typing_extensions import Literal
 
 from shogun.argparse_.action import FieldAction
-from shogun.dispatch.base import DispatcherBase
+from shogun.dispatch.base import DispatchPriority, DispatcherBase
 from shogun.dispatch.concrete.default import DispatcherDefault
 from shogun.generics import get_generic_args, get_generic_origin
 from shogun.utils import IS_PYTHON_36
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class DispatcherLiteral(DispatcherBase):
-    priority: int = 1
+    priority: int = DispatchPriority.SIMPLE_TYPES
 
     @classmethod
     def is_type(cls, field_type: type) -> bool:

--- a/shogun/dispatch/registry.py
+++ b/shogun/dispatch/registry.py
@@ -14,7 +14,7 @@ class TypeRegistry:
 
     @classmethod
     def dispatchers(cls) -> Iterable[Type["DispatcherBase"]]:
-        for priority, dispatchers in sorted(cls._dispatch.items()):
+        for priority, dispatchers in sorted(cls._dispatch.items(), reverse=True):
             for dispatcher in dispatchers:
                 yield dispatcher
 

--- a/shogun/tests/test_dispatch.py
+++ b/shogun/tests/test_dispatch.py
@@ -1,0 +1,14 @@
+from operator import itemgetter
+
+from shogun.dispatch import TypeRegistry
+from shogun.dispatch.concrete.default import DispatcherDefault
+
+
+def test_dispatch_priorities():
+    dispatchers = [(d.priority, d) for d in TypeRegistry.dispatchers()]
+    reverse_sorted = sorted(dispatchers, key=itemgetter(0), reverse=True)
+    assert dispatchers == reverse_sorted
+
+
+def test_last_dispatcher_is_default():
+    assert list(TypeRegistry.dispatchers())[-1] is DispatcherDefault


### PR DESCRIPTION
That way we can define a user specified priority that is trivially
higher than all other priorities - we also supply a default priority
that is the "highest" that users can use via an Enum